### PR TITLE
Separate a plugin to normalize date format for submit

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,22 +1,5 @@
 $(function () {
-  $("input.datepicker").each((_, item) => {
-    var el = $(item);
-
-    // add alt field for datepicker input
-
-    var name = el.attr("name");
-    // var dateEl = $(`<input type="hidden" name="${name}">`);
-    var dateEl = $(`<input type="text" name="${name}">`);
-
-    el.datepicker({
-      format: "yyyy年mm月dd日",
-      language: "zh-CN",
-    }).on("changeDate", (e) => {
-      dateEl.val(e.format("yyyy-mm-dd"));
-    });
-
-    el.datepicker("setDate", el.val());
-
-    el.parent().append(dateEl);
+  $("input.datepicker").datepicker({
+    uniformFormat: "mm-dd-yyyy",
   });
 });

--- a/index.html
+++ b/index.html
@@ -47,6 +47,8 @@
               name="student[birth_date]"
               id="student_birth_date"
               value="2023-02-21"
+              data-date-format="yyyy年mm月dd日"
+              data-date-language="zh-CN"
             />
             <input
               type="text"
@@ -54,6 +56,8 @@
               name="student[apply_due_date]"
               id="student_apply_due_date"
               value="2023-02-22"
+              data-date-format="yyyy年mm月dd日"
+              data-date-language="zh-CN"
             />
           </div>
         </div>
@@ -71,6 +75,7 @@
       src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.9.0/locales/bootstrap-datepicker.zh-CN.min.js"
       charset="UTF-8"
     ></script>
+    <script src="./uniform-date-format.js"></script>
     <script src="./app.js"></script>
   </body>
 </html>

--- a/uniform-date-format.js
+++ b/uniform-date-format.js
@@ -1,0 +1,27 @@
+(function ($) {
+  var originDatepicker = $.fn.datepicker;
+
+  $.fn.datepicker = function (options) {
+    this.each(function () {
+      var el = $(this);
+
+      var uniformFormat =
+        options.uniformFormat || el.data("date-uniform-format") || "yyyy-mm-dd";
+
+      // add alt field for datepicker input
+
+      var name = el.attr("name");
+      var dateEl = $(`<input type="hidden">`).attr("name", name);
+
+      el.attr("name", null);
+
+      originDatepicker.call(el, options).on("changeDate", (e) => {
+        dateEl.val(e.format(uniformFormat));
+      });
+
+      originDatepicker.call(el, "setDate", el.val());
+
+      el.parent().append(dateEl);
+    });
+  };
+})(jQuery);


### PR DESCRIPTION
By loading a separate JavaScript file to normalize date format for submission, users can easily use the general datepicker API.

- add one option `uniformFormat` as the preferred date format for submission. Default is ISO8601 standard: `yyyy-mm-dd`.


Please refer to the bootstrap-datepicker documents for more details https://bootstrap-datepicker.readthedocs.io/en/latest/options.html#format